### PR TITLE
Don't block startup on endless user check

### DIFF
--- a/mautrix_telegram/__main__.py
+++ b/mautrix_telegram/__main__.py
@@ -104,7 +104,7 @@ class TelegramBridge(Bridge):
         if self.config["bridge.resend_bridge_info"]:
             self.add_startup_actions(self.resend_bridge_info())
 
-        # Do not block startup on this
+        # Explicitly not a startup_action, as startup_actions block startup
         self.periodic_sync_task = asyncio.create_task(self._loop_active_puppet_metric())
         
 

--- a/mautrix_telegram/__main__.py
+++ b/mautrix_telegram/__main__.py
@@ -157,15 +157,14 @@ class TelegramBridge(Bridge):
                 await asyncio.sleep(ACTIVE_USER_METRICS_INTERVAL_S)
             except asyncio.CancelledError:
                 return
-            self.log.info("Executing periodic active puppet metric check")
+            self.log.debug("Executing periodic active puppet metric check")
             try:
                 await self._update_active_puppet_metric()
             except asyncio.CancelledError:
                 return
             except Exception as e:
                 self.log.exception(f"Error while checking: {e}")
-
-
+    
     async def manhole_global_namespace(self, user_id: UserID) -> Dict[str, Any]:
         return {
             **await super().manhole_global_namespace(user_id),


### PR DESCRIPTION
The mautrix/python lib will await the result of the startup tasks before enabling prometheus.