### PR TITLE
Allow disabling Telegram status updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 The Element fork includes the following changes:
  - Add config limits for portal rooms https://github.com/mautrix/telegram/pull/469
  - Make max_initial_member_sync work for Chats as well as Channels https://github.com/mautrix/telegram/pull/680
+ - Allow disabling user status updates from Telegram side https://github.com/vector-im/mautrix-telegram/pull/9
 
 Some changes that appear here may get upstreamed to https://github.com/mautrix/telegram, and will be removed from
 the list when they appear in both versions.

--- a/mautrix_telegram/abstract_user.py
+++ b/mautrix_telegram/abstract_user.py
@@ -393,6 +393,8 @@ class AbstractUser(ABC):
             self.log.warning(f"Unexpected other user info update: {type(update)}")
 
     async def update_status(self, update: UpdateUserStatus) -> None:
+        if not config.get("bridge.handle_update_user_status", True):
+            return
         puppet = pu.Puppet.get(TelegramID(update.user_id))
         if isinstance(update.status, UserStatusOnline):
             await puppet.default_mxid_intent.set_presence(PresenceState.ONLINE)

--- a/mautrix_telegram/config.py
+++ b/mautrix_telegram/config.py
@@ -200,6 +200,8 @@ class Config(BaseBridgeConfig):
             copy("bridge.relaybot.whitelist")
             copy("bridge.relaybot.ignore_own_incoming_events")
 
+        copy("bridge.handle_update_user_status")
+
         copy("telegram.api_id")
         copy("telegram.api_hash")
         copy("telegram.bot_token")

--- a/mautrix_telegram/example-config.yaml
+++ b/mautrix_telegram/example-config.yaml
@@ -454,6 +454,10 @@ bridge:
         # Should the bridge block traffic when a limit has been reached
         block_on_limit_reached: false
 
+    # Process puppet presence events ie UpdateUserStatus
+    # Disabling this means we don't try to set presence for puppets
+    handle_update_user_status: true
+
 
 # Telegram config
 telegram:


### PR DESCRIPTION
If the homeserver doesn't handle presence, not much point doing these.