### PR TITLE
Speed up RMAU calculations

### DIFF
--- a/mautrix_telegram/__main__.py
+++ b/mautrix_telegram/__main__.py
@@ -145,8 +145,8 @@ class TelegramBridge(Bridge):
 
     async def _update_active_puppet_metric(self) -> None:
         active_users = UserActivity.get_active_count(
-            self.config['bridge.limits.puppet_inactivity_days'],
             self.config['bridge.limits.min_puppet_activity_days'],
+            self.config['bridge.limits.puppet_inactivity_days'],
         )
 
         block_on_limit_reached = self.config['bridge.limits.block_on_limit_reached']

--- a/mautrix_telegram/db/user_activity.py
+++ b/mautrix_telegram/db/user_activity.py
@@ -69,7 +69,7 @@ class UserActivity(Base):
 
     @classmethod
     def get_active_count(cls, min_activity_days: int, max_activity_days: Optional[int]) -> int:
-        current_ms = time.time() / 1000
+        current_ms = time.time() * 1000
         active_count = 0
         for user in cls._select_all():
             activity_days = (user.last_activity_ts - user.first_activity_ts / 1000) / ONE_DAY_MS


### PR DESCRIPTION
This is still a blocking query (since our entire sqlalchemy setup is not async), and we could technically run it in an executor with a separate session, but the query currently needs less than 20ms for ~100k users so it should not longer be noticeable in practice.