### PR TITLE
Don't block connections on startup

### DIFF
--- a/mautrix_telegram/__init__.py
+++ b/mautrix_telegram/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "0.10.2-mod-1"
+__version__ = "0.10.2-mod-2"
 __author__ = "Tulir Asokan <tulir@maunium.net>"

--- a/mautrix_telegram/__main__.py
+++ b/mautrix_telegram/__main__.py
@@ -98,14 +98,7 @@ class TelegramBridge(Bridge):
         init_formatter(context)
         init_portal(context)
         self.add_startup_actions(init_puppet(context))
-        init_users_task = init_user(context)
-
-        if self.config["telegram.connection.block_startup"] is not False:
-            self.log.info("Connecting users to Telegram before starting up")
-            self.add_startup_actions(init_users_task)
-        else:
-            self.log.info("Connecting users to Telegram in the background")
-            self.loop.create_task(init_users_task)
+        self.add_startup_actions(init_user(context))
 
         if self.bot:
             self.add_startup_actions(self.bot.start())

--- a/mautrix_telegram/__main__.py
+++ b/mautrix_telegram/__main__.py
@@ -98,7 +98,15 @@ class TelegramBridge(Bridge):
         init_formatter(context)
         init_portal(context)
         self.add_startup_actions(init_puppet(context))
-        self.add_startup_actions(init_user(context))
+        init_users_task = init_user(context)
+
+        if self.config["telegram.connection.block_startup"] is not False:
+            self.log.info("Connecting users to Telegram before starting up")
+            self.add_startup_actions(init_users_task)
+        else:
+            self.log.info("Connecting users to Telegram in the background")
+            self.loop.create_task(init_users_task)
+
         if self.bot:
             self.add_startup_actions(self.bot.start())
         if self.config["bridge.resend_bridge_info"]:

--- a/mautrix_telegram/config.py
+++ b/mautrix_telegram/config.py
@@ -213,6 +213,7 @@ class Config(BaseBridgeConfig):
         copy("telegram.connection.flood_sleep_threshold")
         copy("telegram.connection.request_retries")
         copy("telegram.connection.block_startup")
+        copy("telegram.connection.concurrent_connections_startup")
 
         copy("telegram.device_info.device_model")
         copy("telegram.device_info.system_version")

--- a/mautrix_telegram/config.py
+++ b/mautrix_telegram/config.py
@@ -212,6 +212,7 @@ class Config(BaseBridgeConfig):
         copy("telegram.connection.retry_delay")
         copy("telegram.connection.flood_sleep_threshold")
         copy("telegram.connection.request_retries")
+        copy("telegram.connection.block_startup")
 
         copy("telegram.device_info.device_model")
         copy("telegram.device_info.system_version")

--- a/mautrix_telegram/example-config.yaml
+++ b/mautrix_telegram/example-config.yaml
@@ -505,6 +505,13 @@ telegram:
         # is not recommended, since some requests can always trigger a call fail (such as searching
         # for messages).
         request_retries: 5
+        # Should the bridge block startup until all telegram connections have been made for all puppets.
+        # This should be disable for bridges with a large amount of puppets to prevent an extended startup
+        # period. Defaults to true
+        block_startup: true
+        # How many concurrent connections should be handled on startup. Set to 0 to allow unlimited connections
+        # Defualts to 0
+        concurrent_connections_startup: 0
 
     # Device info sent to Telegram.
     device_info:

--- a/mautrix_telegram/user.py
+++ b/mautrix_telegram/user.py
@@ -54,6 +54,7 @@ SearchResult = NamedTuple('SearchResult', puppet='pu.Puppet', similarity=int)
 
 METRIC_LOGGED_IN = Gauge('bridge_logged_in', 'Users logged into bridge')
 METRIC_CONNECTED = Gauge('bridge_connected', 'Users connected to Telegram')
+METRIC_CONNECTING = Gauge('bridge_connecting', 'Users connecting to Telegram')
 
 BridgeState.human_readable_errors.update({
     "tg-not-connected": "Your Telegram connection failed",
@@ -204,7 +205,11 @@ class User(AbstractUser, BaseUser):
         if not self.puppet_whitelisted or self.connected:
             return self
         async with self._ensure_started_lock:
-            return cast(User, await super().ensure_started(even_if_no_session))
+            try:
+                METRIC_CONNECTING.inc()
+                return cast(User, await super().ensure_started(even_if_no_session))
+            finally:
+                METRIC_CONNECTING.dec()
 
     async def start(self, delete_unless_authenticated: bool = False) -> 'User':
         try:

--- a/mautrix_telegram/user.py
+++ b/mautrix_telegram/user.py
@@ -684,11 +684,11 @@ def init(context: 'Context') -> Future:
     global config
     config = context.config
     User.bridge = context.bridge
-    concurrency = config["telegram.connection.concurrent_connections_startup"]
+    concurrency = config.get("telegram.connection.concurrent_connections_startup", 0)
     semaphore = None
-    block_startup = config["telegram.connection.block_startup"]
+    block_startup = config.get("telegram.connection.block_startup", True)
 
-    if concurrency > 0:
+    if concurrency:
         semaphore = asyncio.Semaphore(concurrency)
 
     async def sem_task(task, index):


### PR DESCRIPTION
This is an attempt to address https://github.com/mautrix/telegram/issues/697

This PR changes the code so that starting up connections to Telegram now can be configured to happen behind the scenes (potentially, it might be worth just making this the default). We also have a semaphore lock so that we don't try to reconnect everyone at once and lose the disadvantage of lazy-loading in connections as Matrix users talk.