### PR TITLE
Add metrics for Appservice's Connection Pool stats

### DIFF
--- a/mautrix_telegram/__main__.py
+++ b/mautrix_telegram/__main__.py
@@ -209,7 +209,7 @@ class TelegramBridge(Bridge):
             except Exception as e:
                 self.log.exception(f"Error while checking AS connection pool stats: {e}")
 
-            await asyncio.sleep(1)
+            await asyncio.sleep(15)
     
     async def manhole_global_namespace(self, user_id: UserID) -> Dict[str, Any]:
         return {


### PR DESCRIPTION
It's disgusting but seems to work, as far as I can tell – shows me 0 on the "active" front though, presumably because I can't simulate enough AS traffic locally.