### PR TITLE
Change bridge liveness based on incoming Telegram events

### DIFF
--- a/mautrix_telegram/__main__.py
+++ b/mautrix_telegram/__main__.py
@@ -119,7 +119,7 @@ class TelegramBridge(Bridge):
             self.as_connection_metric_task = self.loop.create_task(self._loop_check_as_connection_pool())
 
         if self.config['telegram.liveness_timeout'] and self.config['telegram.liveness_timeout'] >= 1:
-            self.loop.create_task(self._loop_check_bridge_liveness())
+            self.as_bridge_liveness_task = self.loop.create_task(self._loop_check_bridge_liveness())
 
     async def start(self) -> None:
         await super().start()
@@ -157,6 +157,8 @@ class TelegramBridge(Bridge):
     def prepare_stop(self) -> None:
         if self.periodic_sync_task:
             self.periodic_sync_task.cancel()
+        if self.as_bridge_liveness_task:
+            self.as_bridge_liveness_task.cancel()
         for puppet in Puppet.by_custom_mxid.values():
             puppet.stop()
         self.shutdown_actions = (user.stop() for user in User.by_tgid.values())

--- a/mautrix_telegram/__main__.py
+++ b/mautrix_telegram/__main__.py
@@ -118,7 +118,7 @@ class TelegramBridge(Bridge):
         if self.config['metrics.enabled']:
             self.as_connection_metric_task = self.loop.create_task(self._loop_check_as_connection_pool())
 
-        if self.config['telegram.liveness_timeout']:
+        if self.config['telegram.liveness_timeout'] and self.config['telegram.liveness_timeout'] >= 1:
             self.loop.create_task(self._loop_check_bridge_liveness())
 
     async def start(self) -> None:
@@ -235,7 +235,7 @@ class TelegramBridge(Bridge):
 
     async def _loop_check_bridge_liveness(self) -> None:
         while True:
-            if self.latest_telegram_update_timestamp and self.latest_telegram_update_timestamp < time() - PORTAL_INACTIVE_THRESHOLD:
+            if self.latest_telegram_update_timestamp and self.latest_telegram_update_timestamp < time() - self.config['telegram.liveness_timeout']:
                 self.az.live = False
 
             await asyncio.sleep(15)

--- a/mautrix_telegram/__main__.py
+++ b/mautrix_telegram/__main__.py
@@ -249,9 +249,6 @@ class TelegramBridge(Bridge):
             "Puppet": Puppet,
         }
 
-    def update_bridge_readiness(self):
-        time()
-
     @property
     def manhole_banner_program_version(self) -> str:
         return f"{super().manhole_banner_program_version} and Telethon {__telethon_version__}"

--- a/mautrix_telegram/__main__.py
+++ b/mautrix_telegram/__main__.py
@@ -46,8 +46,6 @@ try:
 except ImportError:
     prometheus = None
 
-PORTAL_INACTIVE_THRESHOLD = 2 * 60 # 2 minutes
-
 ACTIVE_USER_METRICS_INTERVAL_S = 15 * 60 # 15 minutes
 METRIC_ACTIVE_PUPPETS = Gauge('bridge_active_puppets_total', 'Number of active Telegram users bridged into Matrix')
 METRIC_BLOCKING = Gauge('bridge_blocked', 'Is the bridge currently blocking messages')

--- a/mautrix_telegram/__main__.py
+++ b/mautrix_telegram/__main__.py
@@ -168,9 +168,9 @@ class TelegramBridge(Bridge):
     def update_bridge_readiness(self):
         for portal in Portal.all():
             if portal.latest_event_timestamp and portal.latest_event_timestamp < time() - PORTAL_INACTIVE_THRESHOLD:
-                self.az.ready = False
+                self.az.live = False
                 return
-        self.az.ready = True
+        self.az.live = True
 
     async def _update_active_puppet_metric(self) -> None:
         active_users = UserActivity.get_active_count(

--- a/mautrix_telegram/__main__.py
+++ b/mautrix_telegram/__main__.py
@@ -117,7 +117,7 @@ class TelegramBridge(Bridge):
         if self.config['metrics.enabled']:
             self.as_connection_metric_task = self.loop.create_task(self._loop_check_as_connection_pool())
 
-        if self.config['telegram.liveness_timeout'] and self.config['telegram.liveness_timeout'] >= 1:
+        if self.config.get('telegram.liveness_timeout', 0) >= 1:
             self.as_bridge_liveness_task = self.loop.create_task(self._loop_check_bridge_liveness())
 
     async def start(self) -> None:
@@ -236,7 +236,7 @@ class TelegramBridge(Bridge):
 
     async def _loop_check_bridge_liveness(self) -> None:
         while True:
-            if self.latest_telegram_update_timestamp and self.latest_telegram_update_timestamp < time() - self.config['telegram.liveness_timeout']:
+            if self.latest_telegram_update_timestamp and self.latest_telegram_update_timestamp < time() - self.config.get('telegram.liveness_timeout'):
                 self.az.live = False
 
             await asyncio.sleep(15)

--- a/mautrix_telegram/__main__.py
+++ b/mautrix_telegram/__main__.py
@@ -73,6 +73,7 @@ class TelegramBridge(Bridge):
     is_blocked: bool = False
 
     periodic_sync_task: asyncio.Task = None
+    as_bridge_liveness_task: asyncio.Task = None
 
     latest_telegram_update_timestamp: float
 

--- a/mautrix_telegram/abstract_user.py
+++ b/mautrix_telegram/abstract_user.py
@@ -201,7 +201,7 @@ class AbstractUser(ABC):
             self.log.exception("Failed to handle Telegram update")
             UPDATE_ERRORS.labels(update_type=update_type).inc()
         UPDATE_TIME.labels(update_type=update_type).observe(time.time() - start_time)
-        self.brige.update_bridge_readiness()
+        self.brige.confirm_bridge_liveness()
 
     @property
     @abstractmethod

--- a/mautrix_telegram/abstract_user.py
+++ b/mautrix_telegram/abstract_user.py
@@ -201,6 +201,7 @@ class AbstractUser(ABC):
             self.log.exception("Failed to handle Telegram update")
             UPDATE_ERRORS.labels(update_type=update_type).inc()
         UPDATE_TIME.labels(update_type=update_type).observe(time.time() - start_time)
+        self.brige.update_bridge_readiness()
 
     @property
     @abstractmethod

--- a/mautrix_telegram/config.py
+++ b/mautrix_telegram/config.py
@@ -232,6 +232,8 @@ class Config(BaseBridgeConfig):
         copy("telegram.proxy.username")
         copy("telegram.proxy.password")
 
+        copy("telegram.liveness_timeout")
+
     def _get_permissions(self, key: str) -> Permissions:
         level = self["bridge.permissions"].get(key, "")
         admin = level == "admin"

--- a/mautrix_telegram/example-config.yaml
+++ b/mautrix_telegram/example-config.yaml
@@ -546,6 +546,12 @@ telegram:
         username: ""
         password: ""
 
+    # The timeout in seconds after which the bridge reports an error on the /_matrix/mau/live endpoint.
+    # If no events are being received from Telegram this enables a management tool like Kubernetes to
+    # automatically restart the bridge.
+    # Negative values, 0 and no value will make the endpoint always report HTTP 200 after startup.
+    liveness_timeout: 0
+
 # Python logging configuration.
 #
 # See section 16.7.2 of the Python documentation for more info:

--- a/mautrix_telegram/portal/telegram.py
+++ b/mautrix_telegram/portal/telegram.py
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 from typing import Awaitable, Dict, List, Optional, Tuple, Union, NamedTuple, TYPE_CHECKING
 from abc import ABC
-from time import time
 import random
 import mimetypes
 import codecs
@@ -66,8 +65,6 @@ config: Optional['Config'] = None
 
 
 class PortalTelegram(BasePortal, ABC):
-    latest_event_timestamp: float = time()
-
     async def handle_telegram_typing(self, user: p.Puppet, update: UpdateTyping) -> None:
         if user.is_real_user:
             # Ignore typing notifications from double puppeted users to avoid echoing
@@ -616,8 +613,6 @@ class PortalTelegram(BasePortal, ABC):
 
     async def handle_telegram_message(self, source: 'AbstractUser', sender: p.Puppet,
                                       evt: Message) -> None:
-        self.latest_event_timestamp = time()
-
         if self.bridge.is_blocked:
             self.log.debug(f"Bridge is blocked, dropping telegram message {evt.id}")
             return

--- a/mautrix_telegram/portal/telegram.py
+++ b/mautrix_telegram/portal/telegram.py
@@ -616,7 +616,7 @@ class PortalTelegram(BasePortal, ABC):
 
     async def handle_telegram_message(self, source: 'AbstractUser', sender: p.Puppet,
                                       evt: Message) -> None:
-        latest_event_timestamp = time()
+        self.latest_event_timestamp = time()
 
         if self.bridge.is_blocked:
             self.log.debug(f"Bridge is blocked, dropping telegram message {evt.id}")

--- a/mautrix_telegram/portal/telegram.py
+++ b/mautrix_telegram/portal/telegram.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 from typing import Awaitable, Dict, List, Optional, Tuple, Union, NamedTuple, TYPE_CHECKING
 from abc import ABC
+from time import time
 import random
 import mimetypes
 import codecs
@@ -65,6 +66,8 @@ config: Optional['Config'] = None
 
 
 class PortalTelegram(BasePortal, ABC):
+    latest_event_timestamp: float = time()
+
     async def handle_telegram_typing(self, user: p.Puppet, update: UpdateTyping) -> None:
         if user.is_real_user:
             # Ignore typing notifications from double puppeted users to avoid echoing
@@ -613,6 +616,8 @@ class PortalTelegram(BasePortal, ABC):
 
     async def handle_telegram_message(self, source: 'AbstractUser', sender: p.Puppet,
                                       evt: Message) -> None:
+        latest_event_timestamp = time()
+
         if self.bridge.is_blocked:
             self.log.debug(f"Bridge is blocked, dropping telegram message {evt.id}")
             return


### PR DESCRIPTION
Once we've received any update from Telegram the bridge will check every 15 seconds if it recently received messages. If there haven't been recent messages `/_matrix/mau/live` will return an error.
This is configurable as `telegram.liveness_timeout`.