### PR TITLE
Cancel as_connection_metric_task on stop

### DIFF
--- a/mautrix_telegram/__main__.py
+++ b/mautrix_telegram/__main__.py
@@ -73,6 +73,8 @@ class TelegramBridge(Bridge):
 
     periodic_sync_task: asyncio.Task = None
 
+    as_connection_metric_task: asyncio.Task = None
+
     def prepare_db(self) -> None:
         super().prepare_db()
         init_db(self.db)

--- a/mautrix_telegram/__main__.py
+++ b/mautrix_telegram/__main__.py
@@ -149,6 +149,8 @@ class TelegramBridge(Bridge):
     def prepare_stop(self) -> None:
         if self.periodic_sync_task:
             self.periodic_sync_task.cancel()
+        if self.as_connection_metric_task:
+            self.as_connection_metric_task.cancel()
         for puppet in Puppet.by_custom_mxid.values():
             puppet.stop()
         self.shutdown_actions = (user.stop() for user in User.by_tgid.values())


### PR DESCRIPTION
Followup to #22

> @Half-Shot: We should probably cancel the task on shutdown, like we do for the other tasks