### PR TITLE
Set up as_connection_metric_task during `start`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The Element fork includes the following changes:
  - Add `psycopg2`, `uvloop` to requirements.txt, install_requires https://github.com/vector-im/mautrix-telegram/pull/10/files
  - Add metrics about Matrix API calls https://github.com/mautrix/python/pull/68
  - Don't block connections on startup https://github.com/vector-im/mautrix-telegram/pull/20
- - Add metrics for Appservice's Connection Pool stats https://github.com/vector-im/mautrix-telegram/pull/22, https://github.com/vector-im/mautrix-telegram/pull/27
+ - Add metrics for Appservice's Connection Pool stats https://github.com/vector-im/mautrix-telegram/pull/22, https://github.com/vector-im/mautrix-telegram/pull/27, https://github.com/vector-im/mautrix-telegram/pull/29
  - Don't require bot startup for bridge startup https://github.com/vector-im/mautrix-telegram/pull/24
  - Add `telegram.liveness_timeout` config to change `/_matrix/mau/live` when Telegram connections are no longer being received https://github.com/vector-im/mautrix-telegram/pull/23
 

--- a/mautrix_telegram/__init__.py
+++ b/mautrix_telegram/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "0.10.2-mod-5"
+__version__ = "0.10.2-mod-6"
 __author__ = "Tulir Asokan <tulir@maunium.net>"

--- a/mautrix_telegram/__main__.py
+++ b/mautrix_telegram/__main__.py
@@ -224,7 +224,6 @@ class TelegramBridge(Bridge):
     async def _loop_check_as_connection_pool(self) -> None:
         while True:
             try:
-                # a horrible reach into Appservice's internal API
                 connector = self.az.http_session().connector
                 limit = connector.limit
                 # a horrible, horrible reach into asyncio.TCPConnector's internal API

--- a/mautrix_telegram/__main__.py
+++ b/mautrix_telegram/__main__.py
@@ -116,14 +116,14 @@ class TelegramBridge(Bridge):
         if self.config['bridge.limits.enable_activity_tracking'] is not False:
             self.periodic_sync_task = self.loop.create_task(self._loop_active_puppet_metric())
 
-        if self.config['metrics.enabled']:
-            self.as_connection_metric_task = self.loop.create_task(self._loop_check_as_connection_pool())
-
         if self.config.get('telegram.liveness_timeout', 0) >= 1:
             self.as_bridge_liveness_task = self.loop.create_task(self._loop_check_bridge_liveness())
 
     async def start(self) -> None:
         await super().start()
+
+        if self.config['metrics.enabled']:
+            self.as_connection_metric_task = self.loop.create_task(self._loop_check_as_connection_pool())
 
         if self.bot:
             try:
@@ -225,7 +225,7 @@ class TelegramBridge(Bridge):
         while True:
             try:
                 # a horrible reach into Appservice's internal API
-                connector = self.az._http_session.connector
+                connector = self.az.http_session().connector
                 limit = connector.limit
                 # a horrible, horrible reach into asyncio.TCPConnector's internal API
                 # inspired by its (also private) _available_connections()


### PR DESCRIPTION
I think this is one solution to fix #28.

It prevents the http_session being accessed before the it's been created.
Also, it's not as much of a hack because it uses the public method to access `http_session`.