### PR TITLE
Update telemetry support

### DIFF
--- a/mautrix_telegram/config.py
+++ b/mautrix_telegram/config.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 from typing import Any, List, NamedTuple
 import os
+import re
 
 from ruamel.yaml.comments import CommentedMap
 
@@ -108,9 +109,17 @@ class Config(BaseBridgeConfig):
         copy("telemetry.instance_id")
         if base["telemetry.instance_id"] == "generate":
             base["telemetry.instance_id"] = generate_instance_id()
-        copy("telemetry.endpoint")
-        copy("telemetry.retry_count")
-        copy("telemetry.retry_interval")
+
+        copy("telemetry.matrix_destination.room_id_or_alias")
+        copy("telemetry.matrix_destination.room_creation.enabled")
+        copy("telemetry.matrix_destination.room_creation.options")
+
+        copy("telemetry.http_destination.enabled")
+        copy("telemetry.http_destination.credentials.username")
+        copy("telemetry.http_destination.credentials.password")
+        copy("telemetry.http_destination.num_attempts")
+        copy("telemetry.http_destination.retry_delay")
+        copy("telemetry.http_destination.submission_url")
 
         copy("bridge.username_template")
         copy("bridge.alias_template")
@@ -293,3 +302,18 @@ class Config(BaseBridgeConfig):
             return self._get_permissions(homeserver)
 
         return self._get_permissions("*")
+
+    @property
+    def namespaces(self) -> dict[str, list[dict[str, Any]]]:
+        ns = super().namespaces
+        if self["telemetry.matrix_destination.room_creation.enabled"]:
+            telemetry_room_alias = self["telemetry.matrix_destination.room_id_or_alias"]
+            if telemetry_room_alias:
+                aliases = ns.setdefault("aliases", [])
+                aliases.append(
+                    {
+                        "exclusive": False,
+                        "regex": re.escape(telemetry_room_alias),
+                    }
+                )
+        return ns

--- a/mautrix_telegram/example-config.yaml
+++ b/mautrix_telegram/example-config.yaml
@@ -99,19 +99,57 @@ metrics:
 telemetry:
     # Enable usage telemetry. Mandatory for on-premise installations.
     enabled: false
+
     # EMS instance identifier.
     # Set to "generate" to generate and save a new ID.
     # Alternatively, set the "MAUTRIX_TELEGRAM_LICENCE_PATH" environment variable to specify
     # a file to read the ID from, which is generated if it does not exist.
     # If neither instance_id nor a file path are set, a default file is used.
     instance_id: generate
-    # The EMS endpoint to submit telemetry entries to.
-    # If set to a blank string, no telemetry is sent, but is still gathered.
-    endpoint: https://ems.element.io/api/remote/telemetry
-    # How many times to retry sending telemetry if it fails.
-    retry_count: 3
-    # How long to wait between retries, in seconds.
-    retry_interval: 60
+
+    # Config for the Matrix room in which telemetry data will be stored.
+    matrix_destination:
+        # If room creation (see below) is disabled, this must refer to an existing
+        # local or federated room, and the bridge bot will attempt to join it.
+        # If room creation is enabled, this must refer to a local room,
+        # or be left unspecified if the created room does not need an alias.
+        room_id_or_alias:
+
+        # Options for initializing a telemetry room.
+        room_creation:
+            # If disabled, the bridge will not attempt to create a telemetry room,
+            # and "room_id_or_alias" must refer to an existing room.
+            enabled: true
+
+            # Options to pass through to the room creation request
+            # (see "Request body" in the corresponding Matrix spec end-point:
+            # https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3createroom).
+            # If the room referred to by "room_id_or_alias" does not exist, or
+            # if "room_id_or_alias" is unspecified and no telemetry room yet exists,
+            # the bridge will attempt to create a room with the options provided.
+            # This bridge provides sane default creation options which this object
+            # may override (just be careful, e.g. with power levels required by this bridge).
+            # This option is only relevant to when the room is first created (i.e. updating
+            # the option and reloading the bridge will not affect a previously created room).
+            options: {}
+
+    # Optional config for sending telemetry to an external HTTP endpoint.
+    http_destination:
+        # Enable sending telemetry to an endpoint.
+        # If disabled, no telemetry is sent, but is still gathered in a Matrix room.
+        enabled: false
+        # "Basic" HTTP authentication credentials.
+        credentials:
+            username: user
+            password: pass
+        # Per transmission period, the maximum quantity of attempts (during
+        # failures) to make for each request.
+        num_attempts: 3
+        # Quantity of seconds between each request attempt.
+        # Can be a fractional number.
+        retry_delay: 5
+        # Where the telemetry will be POST'ed to.
+        submission_url: https://ems.element.io/api/remote/telemetry
 
 # Manhole config.
 manhole:

--- a/mautrix_telegram/telemetry/config.py
+++ b/mautrix_telegram/telemetry/config.py
@@ -1,0 +1,157 @@
+# mautrix-telegram - A Matrix-Telegram puppeting bridge
+# Copyright (C) 2021 Tulir Asokan
+# Copyright (C) 2022 New Vector Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Union, cast
+import logging
+
+from attr import dataclass, field
+
+from mautrix.types import (
+    IdentifierType,
+    PowerLevelStateEventContent,
+    RoomAlias,
+    RoomCreatePreset,
+    RoomDirectoryVisibility,
+    RoomID,
+)
+
+if TYPE_CHECKING:
+    from attr import Attribute
+
+
+@dataclass
+class Config:
+    instance_id: str
+    matrix_destination: MatrixDestinationConfig
+    http_destination: HTTPDestinationConfig | None
+
+
+class MatrixDestinationConfig:
+    log: logging.Logger = logging.getLogger("mau.telemetry.config")
+
+    room_id_or_alias: RoomIDOrAlias | None = None
+    room_creation_options: dict | None = None
+
+    def __init__(
+        self,
+        room_id_or_alias: RoomID | RoomAlias | None,
+        room_creation_options: dict | None,
+    ):
+        if not room_id_or_alias and room_creation_options is None:
+            raise ValueError(
+                '"telemetry.matrix_destination" must specify at least one of '
+                '"room_id_or_alias" or "room_creation"'
+            )
+
+        if room_id_or_alias:
+            # TODO: when/if there exists a mautrix helper function to validate a room ID/alias, use it
+            self.room_id_or_alias = self.RoomIDOrAlias(room_id_or_alias)
+
+        if room_creation_options is not None:
+
+            def to_plain_dict_recursive(d) -> dict:
+                """Deep-convert a ruamel "Commented" object into a plain one."""
+                p = {**d}
+                for k, v in p.items():
+                    if isinstance(v, dict):
+                        p[k] = to_plain_dict_recursive(v)
+                    elif isinstance(v, list):
+                        p[k] = [*v]
+                return p
+
+            self.room_creation_options = to_plain_dict_recursive(room_creation_options)
+            self._convert_room_creation_options(self.room_creation_options)
+
+    class RoomIDOrAlias:
+        localpart: str
+        domain: str
+
+        _value: RoomID | RoomAlias
+        is_room_id: bool
+
+        def __init__(self, s: str):
+            try:
+                id_type = IdentifierType(s[0])
+                if id_type == IdentifierType.ROOM_ID:
+                    self.is_room_id = True
+                elif id_type == IdentifierType.ROOM_ALIAS:
+                    self.is_room_id = False
+                else:
+                    raise KeyError()
+                self.localpart, self.domain = s[1:].split(":", 1)
+                self._value = cast(Union[RoomID, RoomAlias], s)
+            except:
+                raise ValueError(f'"{s}" is not a valid room ID or alias')
+
+        @property
+        def is_room_alias(self) -> bool:
+            return not self.is_room_id
+
+        def get(self) -> RoomID | RoomAlias:
+            return self._value
+
+        __str__ = get
+
+    def _convert_room_creation_options(self, room_creation_options: dict) -> None:
+        """
+        Convert a room creation options object for the CS API's "createRoom" endpoint
+        into a kwargs object compatible with mautrix-python's "RoomMethods.create_room".
+        """
+        if room_creation_options.pop("room_alias_name", None):
+            self.log.warning(
+                'Ignoring "room_alias_name" in the telemetry room creation config object. '
+                "To specify the alias of the telemetry room to join/create, "
+                'set "telemetry.matrix_destination.room_id_or_alias" instead.'
+            )
+        try:
+            room_creation_options["visibility"] = RoomDirectoryVisibility(
+                room_creation_options.pop("visibility")
+            )
+        except KeyError:
+            pass
+        try:
+            room_creation_options["preset"] = RoomCreatePreset(room_creation_options.pop("preset"))
+        except KeyError:
+            pass
+        try:
+            room_creation_options["invitees"] = room_creation_options.pop("invite")
+        except KeyError:
+            pass
+        try:
+            room_creation_options["power_level_override"] = PowerLevelStateEventContent(
+                **room_creation_options.pop("power_level_content_override")
+            )
+        except KeyError:
+            pass
+
+
+@dataclass
+class HTTPDestinationConfig:
+    num_attempts: int = field(converter=int)
+    retry_delay: float = field(converter=float)
+    submission_url: str
+
+    @num_attempts.validator
+    def _check_num_attempts(self, attribute: Attribute, value: int) -> None:
+        if value <= 0:
+            raise ValueError(f"{attribute.name} must be a positive integer")
+
+    @retry_delay.validator
+    def _check_retry_delay(self, attribute: Attribute, value: float) -> None:
+        if value < 0:
+            raise ValueError(f"{attribute.name} must be non-negative")

--- a/mautrix_telegram/telemetry/format.py
+++ b/mautrix_telegram/telemetry/format.py
@@ -1,0 +1,70 @@
+# mautrix-telegram - A Matrix-Telegram puppeting bridge
+# Copyright (C) 2021 Tulir Asokan
+# Copyright (C) 2022 New Vector Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Helpers to convert telemetry payloads into human-readable formats."""
+
+from typing import List
+
+from attr import asdict, fields, filters
+
+from .types import Telemetry
+
+
+def _get_metadata_rows(telemetry: Telemetry) -> List[str]:
+    return [
+        f"{prop}: {value}"
+        for prop, value in asdict(
+            telemetry,
+            filter=filters.exclude(
+                fields(Telemetry).generationTime,
+                fields(Telemetry).data,
+            ),
+        ).items()
+    ]
+
+
+def telemetry_to_html(telemetry: Telemetry) -> str:
+    return "\n".join(
+        [
+            "<h1>Metadata</h1>",
+            "<ul>",
+        ]
+        + [f"  <li>{row}</li>" for row in _get_metadata_rows(telemetry)]
+        + [
+            "</ul>",
+            "<h1>Data</h1>",
+            "<ul>",
+            f"  <li>rmau.allUsers: {telemetry.data.rmau.allUsers}</li>",
+            "</ul>",
+        ]
+    )
+
+
+def telemetry_to_markdown(telemetry: Telemetry) -> str:
+    return "\n".join(
+        [
+            "# Metadata",
+            "",
+        ]
+        + [f"- {row}" for row in _get_metadata_rows(telemetry)]
+        + [
+            "",
+            "# Data",
+            "",
+            f"- rmau.allUsers: {telemetry.data.rmau.allUsers}",
+            "",
+        ]
+    )

--- a/mautrix_telegram/telemetry/service.py
+++ b/mautrix_telegram/telemetry/service.py
@@ -21,120 +21,227 @@ import asyncio
 import logging
 import time
 
-from aiohttp import ClientSession, hdrs
+from aiohttp import BasicAuth, ClientSession, hdrs
 from attr import dataclass
 
 from mautrix.api import HTTPAPI
 from mautrix.client import ClientAPI
-from mautrix.errors import MNotFound
-from mautrix.types import EventType, RoomID, SerializableAttrs, SerializerError
+from mautrix.errors import MatrixRequestError, MExclusive, MNotFound
+from mautrix.types import (
+    EventType,
+    Format,
+    MessageType,
+    RoomCreateStateEventContent,
+    RoomID,
+    RoomType,
+    SerializableAttrs,
+    SerializerError,
+    TextMessageEventContent,
+)
 
-from .types import TELEMETRY_TYPE, TelemetryData, TelemetryDataRMAU, TelemetryEvent
+from .config import Config, HTTPDestinationConfig, MatrixDestinationConfig
+from .format import telemetry_to_html, telemetry_to_markdown
+from .types import Telemetry as TelemetryEventContent, TelemetryData, TelemetryDataRMAU
 
 if TYPE_CHECKING:
     from ..__main__ import TelegramBridge
 
-TELEMETRY_BASE_TYPE_NAME = f"{TELEMETRY_TYPE}.telemetry"
-TELEMETRY_ROOM_TYPE_NAME = f"{TELEMETRY_BASE_TYPE_NAME}.storage.room"
-TELEMETRY_EVENT_TYPE_NAME = f"{TELEMETRY_BASE_TYPE_NAME}.activity"
 
-TelemetryEventType = EventType.find(TELEMETRY_EVENT_TYPE_NAME, EventType.Class.MESSAGE)
+TelemetryEventType = EventType.find("io.element.ems.telemetry", EventType.Class.MESSAGE)
+
+TelemetryRoomEventType = EventType.find(
+    f"{TelemetryEventType.t}.storage.room", EventType.Class.ACCOUNT_DATA
+)
 
 
 @dataclass
-class TelemetryRoomAccountDataEventContent(SerializableAttrs):
+class TelemetryRoomEventContent(SerializableAttrs):
     room_id: RoomID
 
 
-class TelemetryService:
-    log: logging.Logger = logging.getLogger("mau.telemetry")
+RoomType.TELEMETRY_ROOM = TelemetryRoomEventType.t
+# NOTE: redefining as a global to satisfy static type checks
+TelemetryRoomType: RoomType = RoomType.TELEMETRY_ROOM
 
-    _instance_id: str
+
+class TelemetryService:
+    log: logging.Logger = logging.getLogger("mau.telemetry.service")
+
     _hostname: str
     _matrix_client: ClientAPI
 
-    _endpoint: str
-    _retry_count: int
-    _retry_interval: int
+    _config: Config
 
-    _telemetry_room_id: RoomID | None = None
     _session: ClientSession | None = None
 
     def __init__(self, bridge: TelegramBridge, instance_id: str) -> None:
-        self._instance_id = instance_id
+        if not bridge.config["telemetry.enabled"]:
+            raise ValueError(
+                "TelemetryService cannot be initialized if telemetry is not configured"
+            )
+
         self._hostname = bridge.az.domain
         self._matrix_client = bridge.az.intent
 
-        self._endpoint = bridge.config["telemetry.endpoint"]
-        self._retry_count = bridge.config["telemetry.retry_count"]
-        self._retry_interval = bridge.config["telemetry.retry_interval"]
-        if self._endpoint:
+        self._config = Config(
+            instance_id,
+            MatrixDestinationConfig(
+                bridge.config["telemetry.matrix_destination.room_id_or_alias"],
+                bridge.config["telemetry.matrix_destination.room_creation.options"]
+                if bridge.config["telemetry.matrix_destination.room_creation.enabled"]
+                else None,
+            ),
+            HTTPDestinationConfig(
+                bridge.config["telemetry.http_destination.num_attempts"],
+                bridge.config["telemetry.http_destination.retry_delay"],
+                bridge.config["telemetry.http_destination.submission_url"],
+            )
+            if bridge.config["telemetry.http_destination.enabled"]
+            else None,
+        )
+        if self._config.matrix_destination.room_creation_options is not None:
+            if self._config.matrix_destination.room_id_or_alias and (
+                self._config.matrix_destination.room_id_or_alias.is_room_id
+                or self._config.matrix_destination.room_id_or_alias.domain != self._hostname
+            ):
+                raise ValueError(
+                    '"telemetry.matrix_destination.room_id_or_alias" must refer to a local room alias when '
+                    '"telemetry.matrix_destination.room_creation" is set'
+                )
+
+        if self._config.http_destination:
+            # NOTE: not storing credentials in a config class as they get stored in the ClientSession
             self._session = ClientSession(
                 loop=bridge.loop,
                 headers={
                     hdrs.USER_AGENT: HTTPAPI.default_ua,
                     hdrs.CONTENT_TYPE: "application/json",
                 },
+                auth=BasicAuth(
+                    bridge.config["telemetry.http_destination.credentials.username"],
+                    bridge.config["telemetry.http_destination.credentials.password"],
+                ),
             )
 
     async def _load_storage_room(self) -> RoomID:
-        if self._telemetry_room_id:
-            return self._telemetry_room_id
-
+        remembered_room_id = None
         try:
-            account_data = TelemetryRoomAccountDataEventContent.deserialize(
-                await self._matrix_client.get_account_data(TELEMETRY_ROOM_TYPE_NAME)
-            )
-            room_id = account_data.room_id
+            remembered_room_id = TelemetryRoomEventContent.deserialize(
+                await self._matrix_client.get_account_data(TelemetryRoomEventType)
+            ).room_id
         except (MNotFound, SerializerError):
-            room_id = await self._matrix_client.create_room(
-                creation_content={"type": TELEMETRY_ROOM_TYPE_NAME}
-            )
+            pass
+        except:
+            self.log.exception("Failed to retrieve previously-used telemetry room")
+
+        room_id = None
+        if self._config.matrix_destination.room_id_or_alias:
+            try:
+                room_id = await self._matrix_client.join_room(
+                    self._config.matrix_destination.room_id_or_alias.get(),
+                    max_retries=0,
+                )
+            except MNotFound:
+                if self._config.matrix_destination.room_id_or_alias.is_room_id:
+                    raise
+        elif remembered_room_id:
+            try:
+                room_id = await self._matrix_client.join_room_by_id(remembered_room_id)
+            except Exception as e:
+                self.log.error(
+                    f"Could not join previously-used telemetry room {remembered_room_id}: {e}"
+                )
+
+        if not room_id:
+            if self._config.matrix_destination.room_creation_options is None:
+                raise Exception("Telemetry room creation blocked by config")
+
+            if (
+                self._config.matrix_destination.room_id_or_alias
+                and self._config.matrix_destination.room_id_or_alias.is_room_alias
+            ):
+                alias_localpart = self._config.matrix_destination.room_id_or_alias.localpart
+            else:
+                alias_localpart = None
+            try:
+                room_id = await self._matrix_client.create_room(
+                    alias_localpart,
+                    creation_content=RoomCreateStateEventContent(type=TelemetryRoomType),
+                    **(self._config.matrix_destination.room_creation_options),
+                )
+            except MExclusive as e:
+                raise RuntimeError(
+                    "Failed to create telemetry room with alias "
+                    f'#{alias_localpart}:{self._hostname}". '
+                    "To grant the bridge permission to use this alias, "
+                    "regenerate the bridge registration file."
+                ) from None
+
+        if remembered_room_id and remembered_room_id != room_id:
+            try:
+                await self._matrix_client.leave_room(remembered_room_id)
+            except MatrixRequestError:
+                pass
+            except:
+                self.log.exception("Failed to leave previously-used telemetry room")
+        try:
             await self._matrix_client.set_account_data(
-                TELEMETRY_ROOM_TYPE_NAME, TelemetryRoomAccountDataEventContent(room_id)
+                TelemetryRoomEventType, TelemetryRoomEventContent(room_id).serialize()
             )
-        self._telemetry_room_id = room_id
+        except:
+            self.log.exception("Failed to store telemetry room")
         return room_id
 
     async def send_telemetry(
         self, active_users: int, current_ms: float = time.time() * 1000
     ) -> None:
-        payload = TelemetryEvent(
-            self._instance_id,
-            self._hostname,
-            int(current_ms),
-            TelemetryData(
-                TelemetryDataRMAU(
+        telemetry = TelemetryEventContent(
+            instanceId=self._config.instance_id,
+            hostname=self._hostname,
+            generationTime=int(current_ms),
+            data=TelemetryData(
+                rmau=TelemetryDataRMAU(
                     allUsers=active_users,
-                )
+                ),
             ),
         )
-        self.log.debug(f"Sending telemetry: {payload}")
+        telemetry_json = telemetry.serialize()
+        self.log.debug(f"Sending telemetry: {telemetry_json}")
 
         try:
             room_id = await self._load_storage_room()
-            await self._matrix_client.send_message_event(room_id, TelemetryEventType, payload)
+            human_readable_event_data = TextMessageEventContent(
+                body=telemetry_to_markdown(telemetry),
+                format=Format.HTML,
+                formatted_body=telemetry_to_html(telemetry),
+                msgtype=MessageType.TEXT,
+            )
+            content = human_readable_event_data.serialize()
+            content[TelemetryEventType.t] = telemetry_json
+            await self._matrix_client.send_message(room_id, content)
         except:
             self.log.exception("Failed to record telemetry in Matrix")
 
-        if self._endpoint:
+        if self._config.http_destination:
             assert self._session
-            retries_left = self._retry_count
+            attempts_left = self._config.http_destination.num_attempts
             while True:
                 try:
                     request = self._session.request(
-                        hdrs.METH_POST, self._endpoint, data=payload.serialize()
+                        hdrs.METH_POST,
+                        self._config.http_destination.submission_url,
+                        json=telemetry_json,
                     )
                     async with request as response:
                         response.raise_for_status()
                         break
                 except:
                     self.log.exception("Failed to submit telemetry")
-                    if retries_left > 1:
+                    if attempts_left > 1:
                         self.log.debug(
-                            f"Will retry sending telemetry in {self._retry_interval} seconds"
+                            f"Will retry sending telemetry in {self._config.http_destination.retry_delay} seconds"
                         )
-                        retries_left -= 1
-                        await asyncio.sleep(self._retry_interval)
+                        attempts_left -= 1
+                        await asyncio.sleep(self._config.http_destination.retry_delay)
                     else:
                         break

--- a/mautrix_telegram/telemetry/types.py
+++ b/mautrix_telegram/telemetry/types.py
@@ -14,27 +14,27 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Types to describe the format of telemetry payloads."""
+
 from __future__ import annotations
 
 from attr import dataclass
 
 from mautrix.types import SerializableAttrs
 
-TELEMETRY_TYPE = "net.maunium.telegram"
 
-
-@dataclass
+@dataclass(kw_only=True)
 class TelemetryVersion(SerializableAttrs):
     """
     Telemetry payload properties that describe the format of payloads sent by
     the current version of the bridge.
     """
 
-    version = 1
-    type = TELEMETRY_TYPE
+    version: int = 1
+    type: str = "net.maunium.telegram"
 
 
-@dataclass
+@dataclass(kw_only=True)
 class TelemetryInstance(SerializableAttrs):
     """Telemetry payload properties that depend on bridge configuration."""
 
@@ -42,8 +42,8 @@ class TelemetryInstance(SerializableAttrs):
     hostname: str
 
 
-@dataclass
-class TelemetryEvent(TelemetryVersion, TelemetryInstance):
+@dataclass(kw_only=True)
+class Telemetry(TelemetryVersion, TelemetryInstance):
     """Top-level class for telemetry event payloads."""
 
     generationTime: int


### PR DESCRIPTION
- add config to specify a custom telemetry room to join/create
- render Matrix events in a human-readable format
- support basic auth for HTTP endpoint
- use shared IDs for telemetry event & room types
- refactor for parity with with Synapse telemetry