### PR TITLE
Use fork URLs/versions

### DIFF
--- a/mautrix_telegram/__init__.py
+++ b/mautrix_telegram/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "0.12.1"
+__version__ = "0.12.1-mod-2"
 __author__ = "Tulir Asokan <tulir@maunium.net>"

--- a/mautrix_telegram/__main__.py
+++ b/mautrix_telegram/__main__.py
@@ -61,7 +61,7 @@ class TelegramBridge(Bridge):
     name = "mautrix-telegram"
     command = "python -m mautrix-telegram"
     description = "A Matrix-Telegram puppeting bridge."
-    repo_url = "https://github.com/mautrix/telegram"
+    repo_url = "https://github.com/vector-im/mautrix-telegram"
     version = version
     markdown_version = linkified_version
     config_class = Config

--- a/mautrix_telegram/get_version.py
+++ b/mautrix_telegram/get_version.py
@@ -19,7 +19,7 @@ def run(cmd):
 if os.path.exists(".git") and shutil.which("git"):
     try:
         git_revision = run(["git", "rev-parse", "HEAD"]).strip().decode("ascii")
-        git_revision_url = f"https://github.com/mautrix/telegram/commit/{git_revision}"
+        git_revision_url = f"https://github.com/vector-im/mautrix-telegram/commit/{git_revision}"
         git_revision = git_revision[:8]
     except (subprocess.SubprocessError, OSError):
         git_revision = "unknown"
@@ -34,7 +34,7 @@ else:
     git_revision_url = None
     git_tag = None
 
-git_tag_url = f"https://github.com/mautrix/telegram/releases/tag/{git_tag}" if git_tag else None
+git_tag_url = f"https://github.com/vector-im/mautrix-telegram/releases/tag/{git_tag}" if git_tag else None
 
 if git_tag and __version__ == git_tag[1:].replace("-", ""):
     version = __version__

--- a/mautrix_telegram/get_version.py
+++ b/mautrix_telegram/get_version.py
@@ -34,7 +34,9 @@ else:
     git_revision_url = None
     git_tag = None
 
-git_tag_url = f"https://github.com/vector-im/mautrix-telegram/releases/tag/{git_tag}" if git_tag else None
+git_tag_url = (
+    f"https://github.com/vector-im/mautrix-telegram/releases/tag/{git_tag}" if git_tag else None
+)
 
 if git_tag and __version__ == git_tag[1:].replace("-", ""):
     version = __version__

--- a/mautrix_telegram/portal_util/message_convert.py
+++ b/mautrix_telegram/portal_util/message_convert.py
@@ -530,7 +530,7 @@ class TelegramMessageConverter:
     async def _convert_unsupported(source: au.AbstractUser, evt: Message, **_) -> ConvertedMessage:
         override_text = (
             "This message is not supported on your version of Mautrix-Telegram. "
-            "Please check https://github.com/mautrix/telegram or ask your "
+            "Please check https://github.com/vector-im/mautrix-telegram or ask your "
             "bridge administrator about possible updates."
         )
         content = await formatter.telegram_to_matrix(evt, source, override_text=override_text)

--- a/mautrix_telegram/web/provisioning/spec.yaml
+++ b/mautrix_telegram/web/provisioning/spec.yaml
@@ -5,7 +5,7 @@ info:
   description: The provisioning API for Mautrix-Telegram, the Matrix-Telegram puppeting/relaybot bridge.
   license:
     name: AGPLv3
-    url: https://github.com/mautrix/telegram/blob/master/LICENSE
+    url: https://github.com/vector-im/mautrix-telegram/blob/master/LICENSE
 
 externalDocs:
   description: Provisioning API docs on docs.mau.fi

--- a/setup.py
+++ b/setup.py
@@ -22,9 +22,9 @@ linkified_version = {linkified_version!r}
 setuptools.setup(
     name="mautrix-telegram",
     version=version,
-    url="https://github.com/mautrix/telegram",
+    url="https://github.com/vector-im/mautrix-telegram",
     project_urls={
-        "Changelog": "https://github.com/mautrix/telegram/blob/master/CHANGELOG.md",
+        "Changelog": "https://github.com/vector-im/mautrix-telegram/blob/master/CHANGELOG.md",
     },
 
     author="Tulir Asokan",


### PR DESCRIPTION
This has a few practical benefits:
- The `version` bot command will link to this fork instead of to upstream. (Links work without this, but they give a warning of `This commit does not belong to any branch on this repository, and may belong to a fork outside of the repository.`)
- The `__version__` property of the Python package will represent our fork's version, which may help for scripting & debugging.